### PR TITLE
Add __all__ to clarify that imports are being exported

### DIFF
--- a/libchebipy/__init__.py
+++ b/libchebipy/__init__.py
@@ -25,6 +25,21 @@ from libchebipy._structure import Structure as Structure
 from pandas.stats.interface import ols
 
 
+__all__ = [
+    "ChebiEntity",
+    "ChebiException",
+    "Comment",
+    "CompoundOrigin",
+    "DatabaseAccession",
+    "Formula",
+    "Name",
+    "Reference",
+    "Relation",
+    "Structure",
+    "search",
+]
+
+
 def search(term, exact=False):
     '''Searches ChEBI via ols.'''
     url = 'http://www.ebi.ac.uk/ols/api/search?ontology=chebi' + \


### PR DESCRIPTION
This clarifies that the imports are present so that they can be imported
directly from libchebipy. This also removes warnings around unused
variables.