### PR TITLE
Adding ability to define data download dir in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 libChEBIpy: a Python API for accessing the ChEBI database
 
 Details of the API are available: http://libchebi.github.io/libChEBI%20API.pdf
+
+## Environment
+
+To customize the root of the download directory, set the following environment variable:
+
+```bash
+export LIBCHEBIPY_DOWNLOAD_DIR=/path/to/folder
+```
+
+if not set, the library will default to the folder `libChEBI` in the user's home,
+e.g., `/home/<username>/libChEBI`.

--- a/libchebipy/_parsers.py
+++ b/libchebipy/_parsers.py
@@ -52,7 +52,9 @@ __SOURCES = {}
 __STARS = {}
 __STATUSES = {}
 
-__DOWNLOAD_PARAMS = {'path': os.path.join(os.path.expanduser('~'), 'libChEBI'),
+_download_dir = os.environ.get('LIBCHEBIPY_DOWNLOAD_DIR', os.path.join(os.path.expanduser('~'), 'libChEBI'))
+
+__DOWNLOAD_PARAMS = {'path': _download_dir),
                      'auto_update': True}
 
 


### PR DESCRIPTION
This PR will add an environment variable to make it possible to specify a custom download directory in the environment. I'd like to add support for custom storage (e.g., not the filesystem) and will follow up with another PR for an example of how we might go about doing this without substantially changing the library.

Signed-off-by: vsoch <vsochat@stanford.edu>